### PR TITLE
Update ray to recent version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.9.7-slim
 
-RUN pip install --no-cache-dir -U 'ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl'
+RUN pip install --no-cache-dir -U 'ray[default]'==2.34.0
 
 CMD ["bash", "-c", "ray start --head --num-cpus 1 --dashboard-host 0.0.0.0 --include-dashboard true --block"]


### PR DESCRIPTION
First of all, thank you for your docker-compose files that saves my hours to launch a local cluster!

The prebuilt binary is not compatible with my local environment (M1 Mac), updating to the recent version fixed it.